### PR TITLE
Handle GitHub repository names that contain '.'

### DIFF
--- a/lib/circleci/cli/command/base_command.rb
+++ b/lib/circleci/cli/command/base_command.rb
@@ -25,7 +25,7 @@ module CircleCI
           def reponame
             repository = Rugged::Repository.new('.')
             origin = repository.remotes.find { |r| r.name == 'origin' }
-            regexp = %r{git@github.com(?::|/)([\w_-]+/[\w_-]+)(?:\.git)*}
+            regexp = %r{git@github.com(?::|/)([\w_-]+/[\.\w_-]+?)(?:\.git)*$}
             return Regexp.last_match(1) if origin.url =~ regexp
 
             nil

--- a/spec/circler/command/base_command_spec.rb
+++ b/spec/circler/command/base_command_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CircleCI::CLI::Command::BaseCommand do # rubocop:disable Metrics/BlockLength
+  describe '.reponame' do
+    subject { CircleCI::CLI::Command::BaseCommand.reponame }
+
+    before do
+      mock_remotes = [double('Rugged::Remote', name: 'origin', url: remote_url)]
+      mock_repo = double('Rugged::Repository', remotes: mock_remotes)
+      allow(Rugged::Repository).to receive(:new).with('.').and_return(mock_repo)
+    end
+
+    context 'when git repository has a github remote' do
+      let(:remote_url) { 'git@github.com:user/repository.git' }
+      it 'extracts the reponame from the origin url' do
+        expect(subject).to eq('user/repository')
+      end
+    end
+
+    context 'when git repository has a github remote that contains a dot' do
+      let(:remote_url) { 'git@github.com:user/example.com.git' }
+      it 'extracts the reponame from the origin url, including the dot' do
+        expect(subject).to eq('user/example.com')
+      end
+    end
+
+    context 'when git repository has a non-github remote' do
+      let(:remote_url) { 'git@bitbucket.org:user/repository.git' }
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
It is possible for a GitHub repository to contain the "." character. For example:

    git@github.com:username/example.com.git

Before, circleci-cli would parse this incorrectly, returning `username/example` as the repository name. This commit fixes this bug, such that `username/example.com` is returned as expected.

This fixes the following error when circleci-cli is run in a project that has a '.' in its GitHub repository name:

```
$ circleci-cli builds
Traceback (most recent call last):
  14: from bin/circleci-cli:23:in `<main>'
  13: from bin/circleci-cli:23:in `load'
  12: from lib/ruby/gems/2.6.0/gems/circleci-cli-2.1.0/exe/circleci-cli:6:in `<top (required)>'
  11: from lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
  10: from lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
   9: from lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
   8: from lib/ruby/gems/2.6.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
   7: from lib/ruby/gems/2.6.0/gems/circleci-cli-2.1.0/lib/circleci/cli.rb:33:in `builds'
   6: from lib/ruby/gems/2.6.0/gems/circleci-cli-2.1.0/lib/circleci/cli/command/builds_command.rb:16:in `run'
   5: from lib/ruby/gems/2.6.0/gems/circleci-cli-2.1.0/lib/circleci/cli/response/build.rb:11:in `all'
   4: from lib/ruby/gems/2.6.0/gems/circleci-cli-2.1.0/lib/circleci/cli/response/build.rb:11:in `map'
   3: from lib/ruby/gems/2.6.0/gems/circleci-cli-2.1.0/lib/circleci/cli/response/build.rb:11:in `each'
   2: from lib/ruby/gems/2.6.0/gems/circleci-cli-2.1.0/lib/circleci/cli/response/build.rb:11:in `block in all'
   1: from lib/ruby/gems/2.6.0/gems/circleci-cli-2.1.0/lib/circleci/cli/response/build.rb:11:in `new'
lib/ruby/gems/2.6.0/gems/circleci-cli-2.1.0/lib/circleci/cli/response/build.rb:44:in `initialize': no implicit conversion of String into Integer (TypeError)
```