### PR TITLE
Allow newlines from circle

### DIFF
--- a/lib/circleci/cli/command/watch_command/build_watcher.rb
+++ b/lib/circleci/cli/command/watch_command/build_watcher.rb
@@ -36,7 +36,7 @@ module CircleCI
 
           @client.bind_event_json(channel, 'appendAction') do |json|
             if @verbose
-              say json['out']['message']
+              Thor::Shell::Basic.new.say(json['out']['message'], nil, false)
             else
               @messages[json['step']] << json['out']['message']
             end


### PR DESCRIPTION
Highline adds extra line breaks if the input for says does not end with
space or tab, this uses Thor instead that allows an override of this
behavior.