### PR TITLE
test: improve line coverage with one focused iteration

### DIFF
--- a/spec/circleci/cli/cli_spec.rb
+++ b/spec/circleci/cli/cli_spec.rb
@@ -52,4 +52,35 @@ describe CircleCI::CLI::Runner do
       it { is_expected.to be_nil }
     end
   end
+
+  describe '.start' do
+    [
+      ['projects', [], CircleCI::CLI::Command::ProjectsCommand, { 'pretty' => true }],
+      ['builds', %w[--project octocat/hello-world --branch main], CircleCI::CLI::Command::BuildsCommand,
+       { 'project' => 'octocat/hello-world', 'branch' => 'main', 'all' => false, 'pretty' => true }],
+      ['build', %w[--project octocat/hello-world --build 42], CircleCI::CLI::Command::BuildCommand,
+       { 'project' => 'octocat/hello-world', 'build' => 42, 'last' => false, 'pretty' => true }],
+      ['browse', %w[--project octocat/hello-world --build 42], CircleCI::CLI::Command::BrowseCommand,
+       { 'project' => 'octocat/hello-world', 'build' => 42 }],
+      ['retry', %w[--project octocat/hello-world --build 42], CircleCI::CLI::Command::RetryCommand,
+       { 'project' => 'octocat/hello-world', 'build' => 42 }],
+      ['cancel', %w[--project octocat/hello-world --build 42], CircleCI::CLI::Command::CancelCommand,
+       { 'project' => 'octocat/hello-world', 'build' => 42 }],
+      ['watch', %w[--project octocat/hello-world --branch main --user octocat --verbose],
+       CircleCI::CLI::Command::WatchCommand,
+       { 'project' => 'octocat/hello-world', 'branch' => 'main', 'user' => 'octocat', 'verbose' => true }]
+    ].each do |command_name, arguments, command_class, expected_options|
+      it "routes #{command_name} to #{command_class}" do
+        expect(command_class).to receive(:run) do |options|
+          expect(options.to_h.slice(*expected_options.keys)).to eq(expected_options)
+        end
+
+        described_class.start([command_name, *arguments])
+      end
+    end
+
+    it 'prints the version' do
+      expect { described_class.start(%w[version]) }.to output("#{CircleCI::CLI::VERSION}\n").to_stdout
+    end
+  end
 end

--- a/spec/circleci/cli/command/cancel_command_spec.rb
+++ b/spec/circleci/cli/command/cancel_command_spec.rb
@@ -33,4 +33,16 @@ describe CircleCI::CLI::Command::CancelCommand, type: :command do
     it_behaves_like 'a command asks project name'
     it_behaves_like 'a command cancels build'
   end
+
+  context 'when cancel fails' do
+    let(:project_name) { 'unhappychoice/Circler' }
+    let(:options) { OpenStruct.new(project: project_name, build: 1234) }
+    let(:build_hash) { {} }
+
+    it 'shows failure message' do
+      allow(CircleCI::CLI::Command::CancelCommand).to receive(:say) { nil }
+      expect(CircleCI::CLI::Command::CancelCommand).to receive(:say).with('failed to cancel unhappychoice/Circler 1234.')
+      CircleCI::CLI::Command::CancelCommand.run(options)
+    end
+  end
 end

--- a/spec/circleci/cli/command/cancel_command_spec.rb
+++ b/spec/circleci/cli/command/cancel_command_spec.rb
@@ -41,7 +41,8 @@ describe CircleCI::CLI::Command::CancelCommand, type: :command do
 
     it 'shows failure message' do
       allow(CircleCI::CLI::Command::CancelCommand).to receive(:say) { nil }
-      expect(CircleCI::CLI::Command::CancelCommand).to receive(:say).with('failed to cancel unhappychoice/Circler 1234.')
+      expect(CircleCI::CLI::Command::CancelCommand)
+        .to receive(:say).with('failed to cancel unhappychoice/Circler 1234.')
       CircleCI::CLI::Command::CancelCommand.run(options)
     end
   end

--- a/spec/circleci/cli/command/retry_command_spec.rb
+++ b/spec/circleci/cli/command/retry_command_spec.rb
@@ -41,4 +41,16 @@ describe CircleCI::CLI::Command::RetryCommand, type: :command do
 
     it_behaves_like 'a command retries build'
   end
+
+  context 'when retry fails' do
+    let(:project_name) { 'unhappychoice/Circler' }
+    let(:options) { OpenStruct.new(project: project_name, build: 1234) }
+    let(:build_hash) { {} }
+
+    it 'shows failure message' do
+      allow(CircleCI::CLI::Command::RetryCommand).to receive(:say) { nil }
+      expect(CircleCI::CLI::Command::RetryCommand).to receive(:say).with('failed to trigger unhappychoice/Circler 1234')
+      CircleCI::CLI::Command::RetryCommand.run(options)
+    end
+  end
 end

--- a/spec/circleci/cli/command/watch_command/build_repository_spec.rb
+++ b/spec/circleci/cli/command/watch_command/build_repository_spec.rb
@@ -40,6 +40,21 @@ describe CircleCI::CLI::Command::BuildRepository do
     subject { CircleCI::CLI::Command::BuildRepository.new(build.username, build.reponame).update }
 
     it { is_expected.to match_array [build] }
+
+    it 'updates builds from the branch endpoint when a branch is specified' do
+      expect(CircleCI::CLI::Response::Build).to receive(:all)
+        .with(build.username, build.reponame)
+        .ordered
+        .and_return([build])
+      expect(CircleCI::CLI::Response::Build).to receive(:branch)
+        .with(build.username, build.reponame, 'master')
+        .ordered
+        .and_return([build])
+
+      repository = described_class.new(build.username, build.reponame, branch: 'master')
+
+      expect(repository.update).to match_array([build])
+    end
   end
 
   describe '#mark_as_shown' do

--- a/spec/circleci/cli/command/watch_command/build_watcher_polling_spec.rb
+++ b/spec/circleci/cli/command/watch_command/build_watcher_polling_spec.rb
@@ -86,6 +86,43 @@ describe CircleCI::CLI::Command::BuildWatcher, type: :command do
       expect(watcher).to have_received(:puts).with("\e[1A\e[2K\r#{CircleCI::CLI::Printer.colorize_red('Build')}")
       expect(watcher).to have_received(:say).with('captured output')
     end
+
+    it 'prints new step statuses for success, failure, and in-progress steps' do
+      allow(CircleCI::CLI::Response::Build).to receive(:get).and_return(
+        build_response.call(
+          [
+            step_hash.call(name: 'Build', type: 'build', status: 'success'),
+            step_hash.call(name: 'Test', type: 'test', status: 'failed', index: 1, step: 2),
+            step_hash.call(name: 'Deploy', type: 'deploy', status: 'running', index: 2, step: 3)
+          ]
+        )
+      )
+      allow(watcher).to receive(:puts)
+
+      watcher.instance_variable_set(:@steps, [])
+      watcher.send(:update_build)
+
+      expect(watcher).to have_received(:puts).with("\e[2K\r#{CircleCI::CLI::Printer.colorize_green('Build')}")
+      expect(watcher).to have_received(:puts).with("\e[2K\r#{CircleCI::CLI::Printer.colorize_red('Test')}")
+      expect(watcher).to have_received(:puts).with('Deploy')
+    end
+
+    it 'replaces a running step with a success status line' do
+      allow(CircleCI::CLI::Response::Build).to receive(:get).and_return(
+        build_response.call([step_hash.call(name: 'Build', type: 'build', status: 'success')])
+      )
+      allow(watcher).to receive(:puts)
+
+      watcher.instance_variable_set(
+        :@steps,
+        [build_response.call([step_hash.call(name: 'Build', type: 'build', status: 'running')]).steps.first]
+      )
+      watcher.send(:update_build)
+
+      expect(watcher).to have_received(:puts).with(
+        "\e[1A\e[2K\r#{CircleCI::CLI::Printer.colorize_green('Build')}"
+      )
+    end
   end
 
   describe '#update_actions' do

--- a/spec/circleci/cli/command/watch_command/build_watcher_polling_spec.rb
+++ b/spec/circleci/cli/command/watch_command/build_watcher_polling_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CircleCI::CLI::Command::BuildWatcher, type: :command do
+  let(:thread) { instance_double(Thread, kill: nil) }
+  let(:step_hash) do
+    lambda do |name:, type:, status:, index: 0, step: 0|
+      action = { 'type' => type, 'name' => name, 'status' => status, 'index' => index, 'step' => step }
+      action['end_time'] = '2024-01-01T00:00:00Z' unless status == 'running'
+
+      { 'name' => name, 'actions' => [action] }
+    end
+  end
+  let(:build_response) do
+    lambda do |steps|
+      CircleCI::CLI::Response::Build.new(
+        'username' => 'user',
+        'reponame' => 'repo',
+        'status' => 'running',
+        'build_num' => 1234,
+        'branch' => 'main',
+        'author_name' => 'owner',
+        'subject' => 'Commit',
+        'build_time_millis' => 1000,
+        'start_time' => 100_000,
+        'steps' => steps
+      )
+    end
+  end
+  let(:build) { build_response.call(initial_steps) }
+
+  before do
+    stub_const('CircleCI::CLI::Command::BuildWatcher::HTTPClient', CircleCI::CLI::Networking::HTTPClient)
+  end
+
+  describe '#start' do
+    let(:initial_steps) { [step_hash.call(name: 'Build', type: 'build', status: 'success')] }
+    let(:watcher) { described_class.new(build, verbose: true) }
+    let(:updated_build) do
+      build_response.call(
+        [
+          step_hash.call(name: 'Build', type: 'build', status: 'success'),
+          step_hash.call(name: 'Test', type: 'test', status: 'running', index: 1, step: 2)
+        ]
+      )
+    end
+    let(:shell) { instance_double(Thor::Shell::Basic, say: nil) }
+    let(:response) { instance_double('response', body: 'step output') }
+    let(:url) { 'https://circleci.com/api/private/output/raw/github/user/repo/1234/output/1/2' }
+
+    it 'prints new verbose steps and streams their output' do
+      allow(Thread).to receive(:new) do |&block|
+        block.call
+        thread
+      rescue Interrupt
+        thread
+      end
+      allow(watcher).to receive(:sleep).with(1).and_raise(Interrupt)
+      allow(watcher).to receive(:say)
+      allow(CircleCI::CLI::Response::Build).to receive(:get).and_return(updated_build)
+      allow(CircleCI::CLI::Networking::HTTPClient).to receive(:get).and_return(response)
+      allow(Thor::Shell::Basic).to receive(:new).and_return(shell)
+
+      watcher.start
+
+      expect(watcher).to have_received(:say).with(a_string_including('| Test'))
+      expect(CircleCI::CLI::Networking::HTTPClient).to have_received(:get).with(url, 'Range' => 'bytes=0-')
+      expect(shell).to have_received(:say).with('step output', nil, false)
+    end
+  end
+
+  describe '#update_build' do
+    let(:initial_steps) { [step_hash.call(name: 'Build', type: 'build', status: 'success')] }
+    let(:watcher) { described_class.new(build, verbose: false) }
+    let(:updated_build) { build_response.call([step_hash.call(name: 'Build', type: 'build', status: 'failed')]) }
+
+    it 'prints failed statuses and replays buffered output' do
+      watcher.instance_variable_get(:@messages)['Build'] << 'captured output'
+      allow(CircleCI::CLI::Response::Build).to receive(:get).and_return(updated_build)
+      allow(watcher).to receive(:puts)
+      allow(watcher).to receive(:say)
+
+      watcher.send(:update_build)
+
+      expect(watcher).to have_received(:puts).with("\e[1A\e[2K\r#{CircleCI::CLI::Printer.colorize_red('Build')}")
+      expect(watcher).to have_received(:say).with('captured output')
+    end
+  end
+
+  describe '#update_actions' do
+    let(:initial_steps) { [] }
+    let(:watcher) { described_class.new(build, verbose: false) }
+    let(:current_step) do
+      build_response.call(
+        [step_hash.call(name: 'Test', type: 'test', status: 'running', index: 1, step: 2)]
+      ).steps.first
+    end
+    let(:url) { 'https://circleci.com/api/private/output/raw/github/user/repo/1234/output/1/2' }
+
+    it 'buffers output and skips empty response bodies' do
+      watcher.instance_variable_set(:@current_step, current_step)
+      allow(CircleCI::CLI::Networking::HTTPClient).to receive(:get)
+        .and_return(instance_double('response', body: 'step output'), instance_double('response', body: ''))
+
+      watcher.send(:update_actions)
+      watcher.send(:update_actions)
+
+      expect(CircleCI::CLI::Networking::HTTPClient).to have_received(:get).with(url, 'Range' => 'bytes=0-')
+      expect(CircleCI::CLI::Networking::HTTPClient).to have_received(:get).with(url, 'Range' => 'bytes=11-')
+      expect(watcher.instance_variable_get(:@messages)['Test']).to eq(['step output'])
+    end
+  end
+end

--- a/spec/circleci/cli/command/watch_command_spec.rb
+++ b/spec/circleci/cli/command/watch_command_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CircleCI::CLI::Command::WatchCommand, type: :command do
+  let(:options) { OpenStruct.new(project: 'user/repo', branch: 'main', user: 'octocat', verbose: true) }
+
+  around do |example|
+    state = %i[@options @repository @client @build_watcher].to_h do |ivar|
+      [ivar, described_class.instance_variable_get(ivar)]
+    end
+
+    example.run
+  ensure
+    state.each { |ivar, value| described_class.instance_variable_set(ivar, value) }
+  end
+
+  describe '.run' do
+    let(:repository) { double('repository') }
+    let(:client) { double('client', connect: nil) }
+
+    it 'initializes dependencies and exits on interrupt' do
+      allow(described_class).to receive(:setup_token)
+      allow(described_class).to receive(:bind_status_event)
+      allow(described_class).to receive(:stop_existing_watcher_if_needed)
+      allow(described_class).to receive(:start_watcher_if_needed)
+      allow(described_class).to receive(:sleep).with(1).and_raise(Interrupt)
+      allow(described_class).to receive(:say)
+      allow(CircleCI::CLI::Command::BuildRepository).to receive(:new).and_return(repository)
+      allow(CircleCI::CLI::Networking::CircleCIPusherClient).to receive(:new).and_return(client)
+
+      expect(CircleCI::CLI::Command::BuildRepository).to receive(:new)
+        .with('user', 'repo', branch: 'main', user: 'octocat')
+      expect(client).to receive(:connect)
+      expect(described_class).to receive(:bind_status_event)
+      expect(described_class).to receive(:stop_existing_watcher_if_needed)
+      expect(described_class).to receive(:start_watcher_if_needed)
+      expect(described_class).to receive(:say).with('Exited')
+
+      described_class.run(options)
+    end
+  end
+
+  describe '.bind_status_event' do
+    let(:client) { double('client') }
+    let(:repository) { double('repository') }
+    let(:account) { double('account', pusher_id: 'pusher-id') }
+
+    it 'binds the account event to repository refresh' do
+      described_class.instance_variable_set(:@client, client)
+      described_class.instance_variable_set(:@repository, repository)
+      allow(CircleCI::CLI::Response::Account).to receive(:me).and_return(account)
+
+      expect(client).to receive(:bind).with('private-pusher-id', 'call').and_yield
+      expect(repository).to receive(:update)
+
+      described_class.send(:bind_status_event)
+    end
+  end
+
+  describe '.stop_existing_watcher_if_needed' do
+    let(:build) { double('build', build_number: 42) }
+    let(:watcher) { double('watcher', build:) }
+    let(:repository) { double('repository') }
+    let(:finished_build) { double('finished_build', finished?: true, status: 'success') }
+
+    it 'stops the current watcher when the tracked build has finished' do
+      described_class.instance_variable_set(:@repository, repository)
+      described_class.instance_variable_set(:@build_watcher, watcher)
+      allow(described_class).to receive(:show_interrupted_build_results)
+
+      expect(repository).to receive(:build_for).with(42).and_return(finished_build)
+      expect(watcher).to receive(:stop).with('success')
+      expect(described_class).to receive(:show_interrupted_build_results)
+
+      described_class.send(:stop_existing_watcher_if_needed)
+
+      expect(described_class.instance_variable_get(:@build_watcher)).to be_nil
+    end
+  end
+
+  describe '.start_watcher_if_needed' do
+    let(:waiting_build) { double('waiting_build', running?: false) }
+    let(:running_build) { double('running_build', running?: true, build_number: 42) }
+    let(:repository) { double('repository') }
+    let(:build_watcher) { double('build_watcher', start: nil) }
+
+    it 'starts a watcher for the first running build that has not been shown' do
+      described_class.instance_variable_set(:@options, options)
+      described_class.instance_variable_set(:@repository, repository)
+      described_class.instance_variable_set(:@build_watcher, nil)
+      allow(described_class).to receive(:show_interrupted_build_results)
+      allow(CircleCI::CLI::Command::BuildWatcher).to receive(:new).and_return(build_watcher)
+
+      expect(repository).to receive(:builds_to_show).and_return([waiting_build, running_build])
+      expect(described_class).to receive(:show_interrupted_build_results)
+      expect(repository).to receive(:mark_as_shown).with(42)
+      expect(CircleCI::CLI::Command::BuildWatcher).to receive(:new)
+        .with(running_build, verbose: true)
+      expect(build_watcher).to receive(:start)
+
+      described_class.send(:start_watcher_if_needed)
+
+      expect(described_class.instance_variable_get(:@build_watcher)).to eq(build_watcher)
+    end
+  end
+
+  describe '.show_interrupted_build_results' do
+    let(:options) { OpenStruct.new(verbose: false) }
+    let(:running_build) { double('running_build', finished?: false) }
+    let(:finished_build) do
+      double(
+        'finished_build',
+        finished?: true,
+        username: 'user',
+        reponame: 'repo',
+        build_number: 42,
+        project_name: 'user/repo'
+      )
+    end
+    let(:repository) { double('repository') }
+    let(:response_build) { double('response_build', steps: %w[step], build_number: 42) }
+    let(:step_printer) { double('step_printer', to_s: 'step output') }
+
+    it 'prints finished background builds and marks them as shown' do
+      described_class.instance_variable_set(:@options, options)
+      described_class.instance_variable_set(:@repository, repository)
+      allow(CircleCI::CLI::Response::Build).to receive(:get).and_return(response_build)
+      allow(CircleCI::CLI::Printer::StepPrinter).to receive(:new).and_return(step_printer)
+      allow(described_class).to receive(:say)
+
+      expect(repository).to receive(:builds_to_show).and_return([running_build, finished_build])
+      expect(CircleCI::CLI::Response::Build).to receive(:get).with('user', 'repo', 42)
+      expect(CircleCI::CLI::Printer::BuildPrinter).to receive(:header_for)
+        .with(finished_build, a_string_including('Result of user/repo #42 completed in background'))
+        .and_return('header output')
+      expect(CircleCI::CLI::Printer::StepPrinter).to receive(:new).with(%w[step], pretty: false)
+      expect(described_class).to receive(:say).with('header output')
+      expect(described_class).to receive(:say).with('step output')
+      expect(repository).to receive(:mark_as_shown).with(42)
+
+      described_class.send(:show_interrupted_build_results)
+    end
+  end
+end

--- a/spec/circleci/cli/networking/http_client_spec.rb
+++ b/spec/circleci/cli/networking/http_client_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CircleCI::CLI::Networking::HTTPClient, type: :networking do
+  describe '.get' do
+    let(:url) { 'https://example.com/api/v1/me' }
+    let(:uri) { URI(url) }
+    let(:request) { instance_double(Net::HTTP::Get) }
+    let(:http) { instance_double(Net::HTTP) }
+    let(:response) { instance_double(Net::HTTPOK, body: '{"name":"owner"}') }
+
+    it 'sends headers and parses the JSON response body' do
+      allow(Net::HTTP::Get).to receive(:new).with(uri).and_return(request)
+      allow(request).to receive(:[]=)
+      expect(request).to receive(:[]=).with('Circle-Token', 'token')
+      expect(Net::HTTP).to receive(:start).with('example.com', 443, use_ssl: true).and_yield(http)
+      expect(http).to receive(:request).with(request).and_return(response)
+
+      result = described_class.get(url, 'Circle-Token' => 'token')
+
+      expect(result).to eq('name' => 'owner')
+    end
+  end
+
+  describe '.post_form' do
+    let(:url) { 'https://example.com/auth' }
+    let(:uri) { URI(url) }
+    let(:response) { instance_double(Net::HTTPOK, body: '{"auth":"signed"}') }
+
+    it 'posts params and parses the JSON response body' do
+      expect(Net::HTTP).to receive(:post_form)
+        .with(uri, { socket_id: 'id', channel_name: 'channel' })
+        .and_return(response)
+
+      result = described_class.post_form(url, socket_id: 'id', channel_name: 'channel')
+
+      expect(result).to eq('auth' => 'signed')
+    end
+  end
+end

--- a/spec/circleci/cli/networking/pusher_client_spec.rb
+++ b/spec/circleci/cli/networking/pusher_client_spec.rb
@@ -4,19 +4,68 @@ require 'spec_helper'
 
 describe CircleCI::CLI::Networking::CircleCIPusherClient, type: :networking do
   describe '#connect' do
-    subject { described_class.new.connect }
+    subject(:connect) { client.connect }
 
+    let(:client) { described_class.new }
     let(:mock_socket) { double('socket') }
+    let(:mock_logger) { double('logger') }
+    let(:socket_options) { {} }
 
-    it 'connects to socket' do
-      allow(PusherClient).to receive_message_chain(:logger, :debug)
-      allow(Net::HTTP).to receive(:post_form) { double(body: '{"auth":""}') }
-      allow_any_instance_of(described_class).to receive(:socket) { mock_socket }
+    before do
+      allow(PusherClient).to receive(:logger).and_return(mock_logger)
+      allow(mock_logger).to receive(:level=)
+      allow(mock_socket).to receive(:connect)
+      allow(PusherClient::Socket).to receive(:new) do |key, options|
+        socket_options[:key] = key
+        socket_options.merge!(options)
+        mock_socket
+      end
+    end
 
-      expect(PusherClient).to receive_message_chain(:logger, :level=).with(Logger::ERROR)
-      expect(mock_socket).to receive(:connect).with(true)
+    it 'builds a secure socket and connects to it' do
+      connect
 
-      subject
+      expect(mock_logger).to have_received(:level=).with(Logger::ERROR)
+      expect(socket_options[:key]).to eq('1cf6e0e755e419d2ac9a')
+      expect(socket_options[:secure]).to be(true)
+      expect(socket_options[:auth_method]).to be_a(Proc)
+      expect(socket_options[:logger]).to be_a(Logger)
+      expect(mock_socket).to have_received(:connect).with(true)
+    end
+
+    it 'uses the environment token in the auth callback' do
+      allow(ENV).to receive(:fetch).with('CIRCLE_CI_TOKEN', nil).and_return('token')
+      allow(CircleCI::CLI::Networking::HTTPClient).to receive(:post_form).and_return('auth' => 'signed')
+
+      connect
+
+      channel = double('channel', name: 'private-builds')
+      result = socket_options.fetch(:auth_method).call('socket-id', channel)
+
+      expect(result).to eq('signed')
+      expect(CircleCI::CLI::Networking::HTTPClient).to have_received(:post_form).with(
+        'https://circleci.com/auth/pusher?circle-token=token',
+        socket_id: 'socket-id',
+        channel_name: 'private-builds'
+      )
+    end
+
+    it 'prompts for a token when the environment token is missing' do
+      allow(ENV).to receive(:fetch).with('CIRCLE_CI_TOKEN', nil).and_return(nil)
+      allow(client).to receive(:ask).with('Circle CI token ? :').and_return('prompted-token')
+      allow(CircleCI::CLI::Networking::HTTPClient).to receive(:post_form).and_return('auth' => 'signed')
+
+      connect
+
+      channel = double('channel', name: 'private-builds')
+      socket_options.fetch(:auth_method).call('socket-id', channel)
+
+      expect(client).to have_received(:ask).with('Circle CI token ? :')
+      expect(CircleCI::CLI::Networking::HTTPClient).to have_received(:post_form).with(
+        'https://circleci.com/auth/pusher?circle-token=prompted-token',
+        socket_id: 'socket-id',
+        channel_name: 'private-builds'
+      )
     end
   end
 

--- a/spec/circleci/cli/response/account_spec.rb
+++ b/spec/circleci/cli/response/account_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CircleCI::CLI::Response::Account do
+  describe '#pusher_id' do
+    subject(:pusher_id) { described_class.new('pusher_id' => 'pusher-123').pusher_id }
+
+    it { is_expected.to eq('pusher-123') }
+  end
+
+  describe '.me' do
+    subject(:account) { described_class.me }
+
+    let(:body) { { 'pusher_id' => 'pusher-123' } }
+    let(:response) { double(body: body) }
+    let(:user) { double(me: response) }
+
+    before do
+      allow(CircleCi::User).to receive(:new).and_return(user)
+    end
+
+    it 'returns the current account' do
+      expect(account.pusher_id).to eq('pusher-123')
+      expect(CircleCi::User).to have_received(:new)
+    end
+  end
+end

--- a/spec/circleci/cli/response/action_spec.rb
+++ b/spec/circleci/cli/response/action_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CircleCI::CLI::Response::Action do
+  describe '#log' do
+    subject(:log) { described_class.new(attributes).log }
+
+    let(:attributes) do
+      {
+        'output_url' => 'https://circleci.com/output/123'
+      }
+    end
+    let(:http_client) { class_double(CircleCI::CLI::Networking::HTTPClient) }
+    let(:output) do
+      [
+        { 'message' => "first\r\nline\e[A\r\e[2K" },
+        { 'message' => 'a' * 121 }
+      ]
+    end
+
+    before do
+      stub_const('CircleCI::CLI::Response::Action::HTTPClient', http_client)
+      allow(http_client).to receive(:get)
+        .with('https://circleci.com/output/123')
+        .and_return(output)
+    end
+
+    it 'normalizes and joins log messages' do
+      expect(log).to eq(["first\nline", 'a' * 120, 'a'].join("\n"))
+      expect(http_client).to have_received(:get)
+    end
+  end
+end

--- a/spec/circleci/cli/response/build_spec.rb
+++ b/spec/circleci/cli/response/build_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CircleCI::CLI::Response::Build do
+  let(:base_attributes) do
+    {
+      'username' => 'octocat',
+      'reponame' => 'hello-world',
+      'build_num' => 42,
+      'branch' => 'main',
+      'author_name' => 'octocat',
+      'build_time_millis' => 61_000,
+      'start_time' => '2024-01-01T00:00:00Z'
+    }
+  end
+
+  describe '#running?' do
+    subject(:running?) { described_class.new(base_attributes.merge('status' => 'running')).running? }
+
+    it { is_expected.to be(true) }
+  end
+
+  describe '#channel_name' do
+    subject(:channel_name) { described_class.new(base_attributes).channel_name }
+
+    it { is_expected.to eq('private-octocat@hello-world@42@vcs-github@0') }
+  end
+
+  describe '#information' do
+    subject(:information) { described_class.new(base_attributes.merge('status' => status)).information }
+
+    context 'when the build is canceled' do
+      let(:status) { 'canceled' }
+
+      it 'colorizes the status and branch in yellow' do
+        expect(information[1]).to eq(CircleCI::CLI::Printer.colorize_yellow('canceled'))
+        expect(information[2]).to eq(CircleCI::CLI::Printer.colorize_yellow('main'))
+      end
+    end
+
+    context 'when the build has no tests' do
+      let(:status) { 'no_tests' }
+
+      it 'colorizes the status and branch in light black' do
+        expect(information[1]).to eq(CircleCI::CLI::Printer.colorize_light_black('no_tests'))
+        expect(information[2]).to eq(CircleCI::CLI::Printer.colorize_light_black('main'))
+      end
+    end
+
+    context 'when the build status is not colorized' do
+      let(:status) { 'running' }
+
+      it 'returns the raw status and branch' do
+        expect(information[1]).to eq('running')
+        expect(information[2]).to eq('main')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
A test-only PR aimed at improving line coverage. No production code changes — only RSpec specs were added for previously uncovered code paths.

## Changes
- Added specs for `CircleCI::CLI` (Thor runner) verifying `.start` routes each subcommand correctly
- Added specs for the `WatchCommand` family (`watch_command`, `build_watcher`, `build_repository`) covering polling, step transitions, and output buffering
- Added failure-path specs for `CancelCommand` and `RetryCommand`
- Added new specs for `Networking::HTTPClient.get` / `.post_form`
- Expanded specs for `Networking::CircleCIPusherClient#connect`, including the `auth_method` callback for both env-token and prompt-token paths
- Added specs for the main methods of `Response::Account`, `Response::Action`, and `Response::Build`

## Test plan
- No production code modified; only specs added
- Confirmed overall line coverage goes up
- `bundle exec rspec`, lint, and format all pass