### PR TITLE
chore(deps): bump Ruby floor to 3.3 to unblock Dependabot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.4.4', '3.3.8', '3.2.8', '3.1.7']
+        ruby: ['3.4.4', '3.3.8']
     steps:
       - uses: actions/checkout@master
       - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.3
 
 Style/Documentation:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,18 +15,19 @@ GEM
   remote: https://rubygems.org/
   specs:
     abbrev (0.1.2)
-    activesupport (7.2.3.1)
+    activesupport (8.1.3)
       base64
-      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      json
       logger (>= 1.4.2)
-      minitest (>= 5.1, < 6)
+      minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
@@ -36,7 +37,7 @@ GEM
       io-event (~> 1.11)
       metrics (~> 0.12)
       traces (~> 0.18)
-    async-http (0.95.0)
+    async-http (0.95.1)
       async (>= 2.10.2)
       async-pool (~> 0.11)
       io-endpoint (~> 0.14)
@@ -47,7 +48,7 @@ GEM
       protocol-http2 (~> 0.26)
       protocol-url (~> 0.2)
       traces (~> 0.10)
-    async-http-faraday (0.22.0)
+    async-http-faraday (0.22.2)
       async-http (~> 0.42)
       faraday
     async-pool (0.11.2)
@@ -60,7 +61,7 @@ GEM
     circleci (2.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     console (1.34.3)
       fiber-annotation
       fiber-local (~> 1.1)
@@ -133,7 +134,9 @@ GEM
     lumberjack (1.4.2)
     method_source (1.1.0)
     metrics (0.15.0)
-    minitest (5.27.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     nenv (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)

--- a/circleci-cli.gemspec
+++ b/circleci-cli.gemspec
@@ -25,7 +25,7 @@ end
 Gem::Specification.new do |spec|
   spec.name                  = 'circleci-cli'
   spec.version               = CircleCI::CLI::VERSION
-  spec.required_ruby_version = '>= 3.1'
+  spec.required_ruby_version = '>= 3.3'
   spec.authors               = ['unhappychoice']
   spec.email                 = ['unhappychoice@gmail.com']
 


### PR DESCRIPTION
## Summary
- Bump `required_ruby_version` to `>= 3.3` in the gemspec
- Drop Ruby 3.1.7 and 3.2.8 from the CI matrix (kept 3.3.8 and 3.4.4)
- Refresh `Gemfile.lock`: activesupport 7.2.3.1 → 8.1.3, connection_pool 2.5.5 → 3.0.2, minitest 5.27.0 → 6.0.6, async-http 0.95.0 → 0.95.1, async-http-faraday 0.22.0 → 0.22.2

The latest releases of the above gems require Ruby >= 3.2 (and async-http 0.95+ needs >= 3.3), which kept Dependabot crashing in the Sorbet validation step (`Error processing X (RuntimeError)` at `update_all_versions.rb:152`) while trying to resolve against the 3.1 floor. Both Ruby 3.1 and 3.2 are EOL as of May 2026, so widening the floor to 3.3 is the cleanest unblock.

Closes unhappychoice/oss-issue-opener#165

## Test plan
- [x] `bundle exec rspec` passes locally on Ruby 3.4 (93 examples, 0 failures)
- [ ] CI green on Ruby 3.3 and 3.4