### PR TITLE
chore: bump BUNDLED WITH to 2.7.2 to unblock releases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,4 +237,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.4.18
+   2.7.2


### PR DESCRIPTION
## Why

The `release` workflow run for v4.0.3 failed in `rubygems/release-gem@v1` ([run](https://github.com/circleci-tools/circleci-cli/actions/runs/30146263127)):

```
bundler: failed to load command: rake
Bundler::Runtime#check_for_activated_spec!: You have already activated openssl 3.3.0,
but your Gemfile requires openssl 4.0.2. Since openssl is a default gem, you can either
remove your dependency on it or try updating to a newer version of bundler that supports
openssl as a default gem. (Gem::LoadError)
```

`rubygems/release-gem` preloads `rubygems-attestation-patch.rb` through `RUBYOPT`, which requires `openssl` before `Bundler.setup` runs — so Ruby 3.4.4's default `openssl 3.3.0` is already activated by the time Bundler tries to load the `openssl 4.0.2` in the lockfile. Bundler 2.4.18 (pinned by `BUNDLED WITH`) cannot handle that; newer Bundler treats openssl as a default gem.

Nothing was published and no tag was pushed — the run aborted before `rake release`, so `master` is still on v4.0.2.

## What

`BUNDLED WITH` 2.4.18 -> 2.7.2 (latest 2.x; sibling repo bitflyer-tools/bitflyer already ships 2.6.9 and released fine today).

## Verification

`bundle install` + `bundle exec rspec` under Ruby 3.4.4 with Bundler 2.7.2: 93 examples, 0 failures.

Once merged, the release workflow can be re-run for v4.0.3.

Refs unhappychoice/oss-issue-opener#284

🤖 Generated with [Claude Code](https://claude.com/claude-code)