### PR TITLE
fix: pin openssl to the default gem version to unblock releases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,10 @@ gem 'github_changelog_generator'
 gem 'guard'
 gem 'guard-rspec'
 gem 'guard-rubocop'
+# Keep in sync with the openssl default gem of the Ruby in .ruby-version:
+# rubygems/release-gem activates it via RUBYOPT before Bundler.setup, and a
+# version mismatch aborts the release with Gem::LoadError.
+gem 'openssl', '3.3.0'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    openssl (4.0.2)
+    openssl (3.3.0)
     parallel (2.1.0)
     parser (3.3.12.0)
       ast (~> 2.4.1)
@@ -231,6 +231,7 @@ DEPENDENCIES
   guard
   guard-rspec
   guard-rubocop
+  openssl (= 3.3.0)
   rake
   rspec
   rubocop


### PR DESCRIPTION
## Why

The `release` workflow still fails after #1045 ([run](https://github.com/circleci-tools/circleci-cli/actions/runs/30146652831)):

```
Bundler::Runtime#check_for_activated_spec!: You have already activated openssl 3.3.0,
but your Gemfile requires openssl 4.0.2. Since openssl is a default gem, ... (Gem::LoadError)
```

`rubygems/release-gem@v1` preloads `rubygems-attestation-patch.rb` via `RUBYOPT`, which requires `openssl` before `Bundler.setup` runs. That activates Ruby 3.4.4's **default** openssl 3.3.0. The lockfile meanwhile resolved `openssl 4.0.2` — `io-stream` only asks for `openssl (>= 3.3)`, and Bundler picks the newest gem on rubygems. Default gem ≠ locked gem, so Bundler aborts.

The Bundler bump in #1045 was the wrong lead: I reproduced this locally on Ruby 3.4.4 and it fails identically on Bundler **2.4.18, 2.7.2 and 4.0.17**. The version in the error message is a red herring.

## What

Pin `openssl` to `3.3.0` in the Gemfile — the version Ruby 3.4.4 (`.ruby-version`) ships as a default gem — so the locked version and the activated default agree. A comment records the coupling so it gets revisited when `.ruby-version` moves.

Note this is a Gemfile-only pin, so the published gem's own dependencies are unaffected.

## Verification

Reproduced and fixed locally under Ruby 3.4.4:

```
$ RUBYOPT=-ropenssl bundle exec rake -T   # before: Gem::LoadError
$ RUBYOPT=-ropenssl bundle exec rake -T   # after:  lists tasks
```

`bundle exec rspec` -> 93 examples, 0 failures. `bundle exec rubocop` -> 61 files, no offenses.

Refs unhappychoice/oss-issue-opener#284

🤖 Generated with [Claude Code](https://claude.com/claude-code)